### PR TITLE
Fix encoding error when loading Mods

### DIFF
--- a/loader/assets/annotate.py
+++ b/loader/assets/annotate.py
@@ -3,9 +3,8 @@ import os
 from xml.etree import ElementTree
 
 import ui.log
-from lxml.etree import XMLParser
 
-
+from loader.assets.utils import create_xml_parser
 
 
 def annotate(corePath):
@@ -14,13 +13,13 @@ def annotate(corePath):
 
     # NOTE: textures and animations do not seem to get annotated.  Should this be replaced?  WP would like to use these to make additional annotations in `haven`.
     texture_names = {}
-    local_texture_names = ElementTree.parse("textures_annotations.xml", parser=XMLParser(recover=True))
+    local_texture_names = ElementTree.parse("textures_annotations.xml", parser=create_xml_parser())
     for region in local_texture_names.findall(".//re[@n]"):
         if not region.get("_annotation"):
             continue
         texture_names[region.get('n')] = region.get("_annotation")
     
-    animations = ElementTree.parse(os.path.join(corePath, "library", "animations"), parser=XMLParser(recover=True))
+    animations = ElementTree.parse(os.path.join(corePath, "library", "animations"), parser=create_xml_parser())
     for assetPos in animations.findall('.//assetPos[@a]'):
         asset_id = assetPos.get('a')
         if not asset_id in texture_names:
@@ -31,8 +30,8 @@ def annotate(corePath):
     animations.write(annotatedPath)
     ui.log.log("  Wrote annotated annimations to {}".format(annotatedPath))
     
-    haven = ElementTree.parse(os.path.join(corePath, "library", "haven"), parser=XMLParser(recover=True))
-    texts = ElementTree.parse(os.path.join(corePath, "library", "texts"), parser=XMLParser(recover=True))
+    haven = ElementTree.parse(os.path.join(corePath, "library", "haven"), parser=create_xml_parser())
+    texts = ElementTree.parse(os.path.join(corePath, "library", "texts"), parser=create_xml_parser())
 
     tids = {}
     # Load texts
@@ -257,7 +256,7 @@ def annotate(corePath):
     # NOTE: maybe refactor to only use the tags for the annotation, as the path is always the same and a bit verbose.
     ui.log.log("  annotate DataLogFragment...")
     # First get gfile names.
-    gfiles = ElementTree.parse(os.path.join(corePath, "library", "gfiles"), parser=XMLParser(recover=True))
+    gfiles = ElementTree.parse(os.path.join(corePath, "library", "gfiles"), parser=create_xml_parser())
     gfilename = {}
     for f in gfiles.getroot():
         id = f.get("id")

--- a/loader/assets/explode.py
+++ b/loader/assets/explode.py
@@ -10,6 +10,8 @@ import lxml.etree
 import png
 import ui.log
 
+from loader.assets.utils import create_xml_parser
+
 PIXEL_SIZE = 4
 RGBA_FORMAT = 4
 HEADER_SIZE = 12
@@ -114,7 +116,7 @@ class Texture:
 def explode(corePath):
     """Decode textures and write them out as individual regions"""
 
-    textures = lxml.etree.parse(os.path.join(corePath, "library", "textures"), parser=lxml.etree.XMLParser(recover=True))
+    textures = lxml.etree.parse(os.path.join(corePath, "library", "textures"), parser=create_xml_parser())
     cims = {}
     export_cims = {}
     

--- a/loader/assets/merge.py
+++ b/loader/assets/merge.py
@@ -241,7 +241,7 @@ def buildLibrary(location: str, mod: str):
             if target not in location_library:  location_library[target] = []
 
             ui.log.log("    {} <= {}".format(target, mod_file))
-            with open(_mod_path(mod_file)) as f:
+            with open(_mod_path(mod_file), 'rb') as f:
                 location_library[target].append(lxml.etree.parse(f, parser=create_xml_parser()))
 
         mod_file = _mod_path(target)

--- a/loader/assets/merge.py
+++ b/loader/assets/merge.py
@@ -13,6 +13,7 @@ import ui.log
 from .explode import Texture
 from .library import PATCHABLE_CIM_FILES, PATCHABLE_XML_FILES
 from .patch import doPatches
+from .utils import create_xml_parser
 
 
 def _detect_textures(coreLibrary, modLibrary, mod):
@@ -241,7 +242,7 @@ def buildLibrary(location: str, mod: str):
 
             ui.log.log("    {} <= {}".format(target, mod_file))
             with open(_mod_path(mod_file)) as f:
-                location_library[target].append(lxml.etree.parse(f, parser=lxml.etree.XMLParser(remove_comments=True)))
+                location_library[target].append(lxml.etree.parse(f, parser=create_xml_parser()))
 
         mod_file = _mod_path(target)
         # try again with the extension ?
@@ -260,7 +261,7 @@ def mods(corePath, activeMods, modPaths):
 
     for filename in PATCHABLE_XML_FILES:
         with open(_core_path(filename), 'rb') as f:
-            coreLibrary[filename] = lxml.etree.parse(f, parser=lxml.etree.XMLParser(recover=True))
+            coreLibrary[filename] = lxml.etree.parse(f, parser=create_xml_parser())
 
     # find the last region in the texture file and remember its index
     # we will need this to add mod textures with consecutive indexes...

--- a/loader/assets/utils/__init__.py
+++ b/loader/assets/utils/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+from lxml import etree
+
+
+def create_xml_parser() -> etree.XMLParser:
+    return etree.XMLParser(recover=True, encoding=os.environ.get('FORCE_PARSER_ENCODING', None))


### PR DESCRIPTION
* Fix Unicode handling by opening file in binary mode in one case. All other cases either pass a string path or already open in binary mode.
* Add ability to override encoding when creating parsers, turns out this wasn't the real problem, etree should be capable of handling the encoding on its own, since xml files can declare their encoding at the top of their document.